### PR TITLE
Consistent version of PhyloNetworks

### DIFF
--- a/topic1-installation.qmd
+++ b/topic1-installation.qmd
@@ -63,14 +63,16 @@ from the tutorial directory (cloned or downloaded earlier)
 to make it easier to use this directory as a julia environment.
 
 Then within julia, install
-[PhyloNetworks](https://juliaphylo.github.io/PhyloNetworks.jl/v0.16/man/installation/)
-v0.16 (see below to install this particular version).
+[PhyloNetworks](https://juliaphylo.github.io/PhyloNetworks.jl/stable/man/installation/).
 Also install other packages, including:
 [PhyloPlots](https://juliaphylo.github.io/PhyloPlots.jl/stable/man/installation/#Installation).
 For this, we suggest using the environment provided in this tutorial,
 which consists of the two `.toml` files that lists which packages to install
 (in `Project.toml`) and which versions exactly (in `Manifest.toml`).
-These installations will not interfere with other ways you might be using julia.
+These installations will not interfere with other ways you might be using julia,
+and will install the exact versions of the packages used while writing this tutorial 
+(see the [readme](https://github.com/JuliaPhylo/networkPCM-tutorial?tab=readme-ov-file) file
+of the GitHub repository).
 Here is how:
 
 - type `]` to switch to package mode
@@ -91,8 +93,8 @@ Then type this:
 add CSV, CategoricalArrays, DataFrames
 add Distributions, StatsBase, StatsModels
 add RCall
-add PhyloNetworks@0.16.4
-add PhyloPlots # do this after adding PhyloNetworks v0.16, to install a compatible version
+add PhyloNetworks
+add PhyloPlots # do this after adding PhyloNetworks, to install a compatible version
 ```
 Installation may take a while, especially if internet is slow.
 

--- a/topic3-averagedistances.qmd
+++ b/topic3-averagedistances.qmd
@@ -42,10 +42,12 @@ of fast-evolving genes, and rate variation across genes more generally.
 
 We first load [helper functions](https://github.com/JuliaPhylo/PhyloUtilities/blob/main/scripts/averagetaxondistances.jl)
 for computing pairwise distances, to
+
 - get a matrix of pairwise distances from each tree
 - normalize these distance matrices, so they all have a similar distance between
   the ingroup and outgroup taxa
 - average distance matrices across genes.
+
 These functions were originally developed by [Karimi et al. (2020)](https://doi.org/10.1093/sysbio/syz073).
 To load them, do this below within your julia session:
 ```{julia}

--- a/topic4-netcalibration.qmd
+++ b/topic4-netcalibration.qmd
@@ -19,7 +19,7 @@ using StatsBase, StatsModels
 We first read the network, as shown in the 'getting started' section.
 In that section,
 the [figure](topic2-getstarted.qmd#fig-0-netsnaq) shows that the network needs
-to be rooted correctely, is missing some edge lengths, and
+to be rooted correctly, is missing some edge lengths, and
 that current edge lengths are in coalescent units.
 These units are expected to correlate poorly with time, because the number of
 generations per year can vary significantly between species,

--- a/topic5-phyloANOVA.qmd
+++ b/topic5-phyloANOVA.qmd
@@ -47,7 +47,7 @@ first(traits_morph, 4)
 ```
 
 Taxon names are in the column "morph", but don't match exactly with the
-names in the network ---somethign quite typical.
+names in the network ---something quite typical.
 
 ```{julia}
 setdiff(tiplabels(net), traits_morph.morph) # names in the network but not in trait df
@@ -76,15 +76,15 @@ subset!(traits_morph, :morph => ByRow(in(tiplabels(net))))
 
 ## phylogenetic regression
 
-Let's fit our model: a Browian motion by default.
+Let's fit our model: a Brownian motion by default.
 The output shows the estimated parameters,
 confidence intervals for the regression coefficients, and other summary.
 
 Functions for trait evolution are in package
 [PhyloTraits](https://juliaphylo.github.io/PhyloTraits.jl/stable/),
 so we load if first.
-We will also need to load package using StatsModels,
-for definting statistical model formulas.
+We will also need to load package `StatsModels`,
+for defining statistical model formulas.
 
 ```{julia}
 using PhyloTraits, StatsModels


### PR DESCRIPTION
Adjust installation instructions to  `PhyloNetworks v1.1.0` instead of `0.16`, as this is the version used in this updated tutorial, as stated in the `readme` file.
